### PR TITLE
Add a direct Omnis start with new start picker

### DIFF
--- a/data/start.txt
+++ b/data/start.txt
@@ -1,0 +1,39 @@
+start "omnis"
+	name "Omnis"
+	description `<Placeholder Omnis Start>`
+	thumbnail "landscape/station6"
+	date 16 11 3013
+	system "Omnis"
+	planet "Everything"
+	conversation "omnis_intro"
+	account
+		credits 922e16
+		score 800
+	set "license: Pilot's"
+	set "license: City-Ship"
+	set "license: Coalition"
+	set "license: Heliarch"
+	set "license: Militia"
+	set "license: Navy Auxiliary"
+	set "license: Navy Carrier"
+	set "license: Navy Cruiser"
+	set "license: Navy"
+	set "license: Remnant Capital"
+	set "license: Remnant"
+	set "license: Unfettered Militia"
+	set "license: Wanderer Military"
+	set "license: Wanderer Outfits"
+	set "license: Wanderer"
+	set "money: offered"
+	set "money: completed"
+	set "omnis start"
+	ship "Caster" "Caster"
+
+
+
+conversation "omnis_intro"
+	`Welcome to Omnis! Please enter your name.`
+	name
+	`	You will begin on a ringworld with all tech in the game, various jobs that give useful benefits, and a portal in-system that will take you to Rutilicus.`
+	`	Every faction in the game has a system you can jump to, as well. Along with a ringworld that is filtered to just have their tech, there are "ships" in system you can hail, which will create a copy of that ship to fight.`
+	`	Have fun!`

--- a/data/start.txt
+++ b/data/start.txt
@@ -1,6 +1,8 @@
 start "omnis"
 	name "Omnis"
-	description `<Placeholder Omnis Start>`
+	description `You will begin on a ringworld with all tech in the game, various jobs that give useful benefits, and a portal in-system that will take you to Rutilicus.`
+	description `	Every faction in the game has a system you can jump to, as well. Along with a ringworld that is filtered to just have their tech, there are "ships" in system you can hail, which will create a copy of that ship to fight.`
+	description `	Have fun!`
 	thumbnail "landscape/station6"
 	date 16 11 3013
 	system "Omnis"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4471575/109728838-96bc0e00-7b7c-11eb-9a59-efbb3cbeda81.png)

This PR adds an Omnis start to the new start picker recently added to Endless Sky. It places the player in the Omnis system with a Caster, the money mission completed, and all licenses unlocked. This lets someone new to the plugin use it much easier, since they won't have to know about the wormhole in Rutilicus, and can just make a new pilot and see the option available. I'd prefer if it could start with the map revealed as well, but that currently isn't supported from the jump.

For the starting conversation, I did a light tutorial on how to get back to human space, as well as how to make use the ship testers. This is just a suggestion, though, as I don't know if you'd want to match a similar tone to the "money" mission or the Everything description, so feel free to run with it or toss it out, depending on what you're looking for. Either way, a direct start will be a very nice improvement now that we have this tech.